### PR TITLE
Fix 500 error for calendar plugin if namespace was deleted/disabled

### DIFF
--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/calendar.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/calendar.html
@@ -1,5 +1,11 @@
 {% load aldryn_events %}
 
 <div class="aldryn aldryn-events aldryn-events-calendar">
-    {% calendar event_year event_month calendar_language calendar_namespace %}
+    {% if plugin_configuration_error %}
+        {% if request.user.is_staff or request.user.is_superuser %}
+            <p class="config-errors">{{ plugin_configuration_error }}</p>
+        {% endif %}
+    {% else %}
+        {% calendar event_year event_month calendar_language calendar_namespace %}
+    {% endif %}
 </div>

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/list/standard/list.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/list/standard/list.html
@@ -2,7 +2,12 @@
 {% load i18n %}
 
 {% block plugin %}
-    <div class="aldryn aldryn-events aldryn-events-listplugin">
+<div class="aldryn aldryn-events aldryn-events-listplugin">
+    {% if plugin_configuration_error %}
+        {% if request.user.is_staff or request.user.is_superuser %}
+            <p class="config-errors">{{ plugin_configuration_error }}</p>
+        {% endif %}
+    {% else %}
         <ul class="list-unstyled">
             {% for event in events %}
                 <li>
@@ -13,5 +18,6 @@
                 <li class="well">{% trans "No items available" %}</li>
             {% endfor %}
         </ul>
-    </div>
+    {% endif %}
+</div>
 {% endblock plugin %}

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/calendar.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/calendar.html
@@ -1,2 +1,8 @@
 {% load aldryn_events %}
-{% calendar event_year event_month calendar_language calendar_namespace %}
+{% if plugin_configuration_error %}
+    {% if request.user.is_staff or request.user.is_superuser %}
+        <p class="config-errors">{{ plugin_configuration_error }}</p>
+    {% endif %}
+{% else %}
+    {% calendar event_year event_month calendar_language calendar_namespace %}
+{% endif %}

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/list/standard/list.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/list/standard/list.html
@@ -3,12 +3,18 @@
 
 {% block plugin %}
 <div class="plugin plugin-events">
-	<ul class="events-list">
-		{% for event in events %}
-		<li><a href="{{ event.get_absolute_url }}">{{ event }}</a> <span class="date">{{ event.start }}</span></li>
-        {% empty %}
-        <li>{% trans "No events found." %}</li>
-		{% endfor %}
-	</ul>
+    {% if plugin_configuration_error %}
+        {% if request.user.is_staff or request.user.is_superuser %}
+            <p class="config-errors">{{ plugin_configuration_error }}</p>
+        {% endif %}
+    {% else %}
+        <ul class="events-list">
+            {% for event in events %}
+                <li><a href="{{ event.get_absolute_url }}">{{ event }}</a> <span class="date">{{ event.start }}</span></li>
+            {% empty %}
+                <li>{% trans "No events found." %}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 </div>
 {% endblock plugin %}

--- a/aldryn_events/tests/test_plugins.py
+++ b/aldryn_events/tests/test_plugins.py
@@ -212,6 +212,37 @@ class EventPluginsTestCase(EventBaseTestCase):
             self.assertEqual(response.status_code, 200)
 
     @mock.patch('aldryn_events.managers.timezone')
+    def test_calendar_plugin_with_not_existing_ns(self, timezone_mock):
+        timezone_mock.now.return_value = tz_datetime(2014, 1, 2)
+        self.create_base_pages()
+        new_config = EventsConfig.objects.create(namespace='new_namespace')
+        page = api.create_page('Plugin test en', self.template, 'en',
+                               published=True, slug='plugin-test-en')
+        api.create_title('de', 'Plugin test de', page)
+        ph = page.placeholders.get(slot='content')
+        api.add_plugin(ph, 'CalendarPlugin', 'en', app_config=new_config)
+        api.add_plugin(ph, 'CalendarPlugin', 'de', app_config=new_config)
+        page.publish('en')
+        page.publish('de')
+
+        with force_language('en'):
+            event = Event.objects.create(
+                title='Test event namespace',
+                slug='test-event-namespace',
+                start_date=tz_datetime(2014, 1, 10),
+                publish_at=tz_datetime(2014, 1, 1),
+                app_config=new_config
+            )
+        event.create_translation(
+            'de',
+            title='Test event namespace de',
+            slug='test-event-namespace-de')
+        for language in ('en', 'de'):
+            page_url = page.get_absolute_url(language)
+            response = self.client.get(page_url)
+            self.assertEqual(response.status_code, 200)
+
+    @mock.patch('aldryn_events.managers.timezone')
     def test_upcoming_plugin_for_past(self, timezone_mock):
         """
         Test the upcoming events plugin for past entries

--- a/aldryn_events/utils.py
+++ b/aldryn_events/utils.py
@@ -4,7 +4,7 @@ import calendar
 
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -241,3 +241,15 @@ def date_or_datetime(d, t):
         return d
     else:
         return None
+
+
+def namespace_is_apphooked(namespace):
+    """
+    Check if provided namespace has an app-hooked page.
+    Returns True or False.
+    """
+    try:
+        reverse('{0}:events_list'.format(namespace))
+    except (NoReverseMatch, AttributeError):
+        return False
+    return True


### PR DESCRIPTION
Also:
* update list plugin templates to display error message for same cases,
* small refactoring
* update template for calendar plugin
* additional testcase to check that there is no error for such cases.