### PR TITLE
Fix plugins forms (#95), respect app configs, filter not published/apphooked configs

### DIFF
--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/list/standard/list.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/list/standard/list.html
@@ -11,8 +11,8 @@
         <ul class="list-unstyled">
             {% for event in events %}
                 <li>
-                    <a href="{{ event.get_absolute_url }}">{{ event }}</a>
-                    <span class="date">{{ event.start|date }}</span>
+                    <a href="{{ event.get_absolute_url }}">{{ event.get_title }}</a>
+                    <span class="date"> {{ event.start|date }}</span>
                 </li>
             {% empty %}
                 <li class="well">{% trans "No items available" %}</li>

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/upcoming/standard/upcoming.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/plugins/upcoming/standard/upcoming.html
@@ -11,8 +11,8 @@
             <ul class="list-unstyled">
                 {% for event in events %}
                     <li>
-                        <a href="{{ event.get_absolute_url }}">{{ event }}</a>
-                        <span class="date">{{ event.start|date }}</span>
+                        <a href="{{ event.get_absolute_url }}">{{ event.get_title }}</a>
+                        <span class="date"> {{ event.start|date }}</span>
                     </li>
                 {% empty %}
                     <li class="well">{% trans "No items available" %}</li>

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/list/standard/list.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/list/standard/list.html
@@ -10,7 +10,7 @@
     {% else %}
         <ul class="events-list">
             {% for event in events %}
-                <li><a href="{{ event.get_absolute_url }}">{{ event }}</a> <span class="date">{{ event.start }}</span></li>
+                <li><a href="{{ event.get_absolute_url }}">{{ event.get_title }}</a> <span class="date">{{ event.start }}</span></li>
             {% empty %}
                 <li>{% trans "No events found." %}</li>
             {% endfor %}

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/upcoming/standard/upcoming.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/plugins/upcoming/standard/upcoming.html
@@ -13,7 +13,7 @@
             {% for event in events %}
                 <li>
                     <p>
-                        <a href="{{ event.get_absolute_url }}">{{ event }}</a> <span class="date">{{ event.start }}</span>
+                        <a href="{{ event.get_absolute_url }}">{{ event.get_title }}</a> <span class="date">{{ event.start }}</span>
                     </p>
                 </li>
             {% empty %}

--- a/aldryn_events/cms_plugins.py
+++ b/aldryn_events/cms_plugins.py
@@ -14,7 +14,10 @@ from .models import (
     UpcomingPluginItem, Event, EventListPlugin, EventCalendarPlugin
 )
 
-from .forms import UpcomingPluginForm
+from .forms import (
+    UpcomingPluginForm, EventListPluginForm, EventCalendarPluginForm,
+)
+
 
 NO_APPHOOK_ERROR_MESSAGE = _(
     'There is an error in plugin configuration: selected Events '
@@ -67,6 +70,7 @@ class EventListCMSPlugin(CMSPluginBase):
     module = _('Events')
     name = _('List')
     model = EventListPlugin
+    form = EventListPluginForm
 
     def render(self, context, instance, placeholder):
         self.render_template = (
@@ -106,6 +110,7 @@ class CalendarPlugin(CMSPluginBase):
     module = _('Events')
     cache = False
     model = EventCalendarPlugin
+    form = EventCalendarPluginForm
 
     def render(self, context, instance, placeholder):
         # # check if we can reverse list view for configured namespace

--- a/aldryn_events/forms.py
+++ b/aldryn_events/forms.py
@@ -2,9 +2,8 @@
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse, NoReverseMatch
 from django.forms import DateTimeField, TimeField, DateField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, ugettext
 from django.utils import timezone
 from django.template import TemplateDoesNotExist
 from django.template.loader import select_template
@@ -14,9 +13,13 @@ from app_data import AppDataForm
 from parler.forms import TranslatableModelForm
 from cms.models import Page
 
-from .models import Registration, UpcomingPluginItem, Event, EventsConfig
+from .models import (
+    Registration, UpcomingPluginItem, Event, EventsConfig,
+    EventListPlugin, EventCalendarPlugin,
+)
 from .utils import (
-    send_user_confirmation_email, send_manager_confirmation_email
+    send_user_confirmation_email, send_manager_confirmation_email,
+    namespace_is_apphooked,
 )
 
 
@@ -115,11 +118,9 @@ class EventRegistrationForm(forms.ModelForm):
         )
 
 
-class UpcomingPluginForm(forms.ModelForm):
-    model = UpcomingPluginItem
-
+class AppConfigPluginFormMixin(object):
     def __init__(self, *args, **kwargs):
-        super(UpcomingPluginForm, self).__init__(*args, **kwargs)
+        super(AppConfigPluginFormMixin, self).__init__(*args, **kwargs)
         # get available event configs, that have the same namespace
         # as pages with namespaces. that will ensure that user wont
         # select config that is not app hooked because that
@@ -128,7 +129,33 @@ class UpcomingPluginForm(forms.ModelForm):
             namespace__in=Page.objects.exclude(
                 application_namespace__isnull=True).values_list(
                 'application_namespace', flat=True))
-        self.fields['app_config'].queryset = available_configs
+
+        published_configs_pks = [
+            config.pk for config in available_configs
+            if namespace_is_apphooked(config.namespace)]
+
+        self.fields['app_config'].queryset = available_configs.filter(
+            pk__in=published_configs_pks)
+        # inform user that there are not published namespaces
+        # which he shouldn't use
+        not_published = available_configs.exclude(
+            pk__in=published_configs_pks).values_list(
+            'namespace', flat=True)
+        msg = ugettext('Following app_configs is app hooked but pages are not '
+                'published, to use them - publish pages to which they are '
+                'attached.')
+        not_published_namespaces = '; '.join(not_published)
+        full_message = '{0} \n<br/>{1}'.format(msg, not_published_namespaces)
+        # update help text
+        if (not self.fields['app_config'].help_text or
+                    len(self.fields['app_config'].help_text.strip()) < 1):
+            self.fields['app_config'].help_text = full_message
+        else:
+            self.fields['app_config'].help_text += full_message
+
+        # pre select app config if there is only one option
+        if self.fields['app_config'].queryset.count() == 1:
+                self.fields['app_config'].empty_label = None
 
     def clean(self):
         # since namespace is not a unique thing we need to validate it
@@ -137,17 +164,18 @@ class UpcomingPluginForm(forms.ModelForm):
         # which also would lead to same 500 error. The easiest way is to try
         # to reverse, in case of success that would mean that the app_config
         # is correct and can be used.
-        data = super(UpcomingPluginForm, self).clean()
-        try:
-            reverse('{0}:events_list'.format(
-                data['app_config'].namespace))
-        except NoReverseMatch:
+        data = super(AppConfigPluginFormMixin, self).clean()
+        if not namespace_is_apphooked(data['app_config'].namespace):
             raise ValidationError(
                 _('Seems that selected Job config is not plugged to any page, '
                   'or maybe that page is not published.'
                   'Please select Job config that is being used.'),
                 code='invalid')
         return data
+
+
+class UpcomingPluginForm(AppConfigPluginFormMixin, forms.ModelForm):
+    model = UpcomingPluginItem
 
     def clean_style(self):
         style = self.cleaned_data.get('style')
@@ -161,6 +189,24 @@ class UpcomingPluginForm(forms.ModelForm):
                 "Not a valid style (Template does not exist)"
             )
         return style
+
+
+class EventListPluginForm(AppConfigPluginFormMixin, forms.ModelForm):
+    model = EventListPlugin
+
+    def clean(self):
+        data = super(EventListPluginForm, self).clean()
+        # save only events for selected app_config
+        selected_events = data.get('events', [])
+        app_config = data['app_config']
+        new_events = [event for event in selected_events
+                      if event.app_config.pk == app_config.pk]
+        data['events'] = new_events
+        return data
+
+
+class EventCalendarPluginForm(AppConfigPluginFormMixin, forms.ModelForm):
+    model = EventCalendarPlugin
 
 
 class EventOptionForm(AppDataForm):

--- a/aldryn_events/forms.py
+++ b/aldryn_events/forms.py
@@ -141,14 +141,15 @@ class AppConfigPluginFormMixin(object):
         not_published = available_configs.exclude(
             pk__in=published_configs_pks).values_list(
             'namespace', flat=True)
-        msg = ugettext('Following app_configs is app hooked but pages are not '
-                'published, to use them - publish pages to which they are '
-                'attached.')
+        msg = ugettext(
+            'Following app_configs is app hooked but pages are not '
+            'published, to use them - publish pages to which they are '
+            'attached.')
         not_published_namespaces = '; '.join(not_published)
         full_message = '{0} \n<br/>{1}'.format(msg, not_published_namespaces)
         # update help text
         if (not self.fields['app_config'].help_text or
-                    len(self.fields['app_config'].help_text.strip()) < 1):
+                len(self.fields['app_config'].help_text.strip()) < 1):
             self.fields['app_config'].help_text = full_message
         else:
             self.fields['app_config'].help_text += full_message

--- a/aldryn_events/models.py
+++ b/aldryn_events/models.py
@@ -165,8 +165,16 @@ class Event(TranslationHelperMixin, TranslatableModel):
         verbose_name_plural = _('Events')
         ordering = ('start_date', 'start_time', 'end_date', 'end_time')
 
-    def __unicode__(self):
+    def get_title(self):
         return self.safe_translation_getter('title', any_language=True)
+
+    def __unicode__(self):
+        # since we now have app configs, it is pretty handy to display it
+        # FIXME: change this to use app_config.app_title instead after it would
+        # be migrated properly.
+        app_config_namespace = self.app_config.namespace
+        return unicode('{0} ({1})'.format(
+            self.get_title(), app_config_namespace))
 
     @property
     def start_at(self):

--- a/aldryn_events/tests/test_managers.py
+++ b/aldryn_events/tests/test_managers.py
@@ -12,13 +12,13 @@ class EventManagerTestCase(EventBaseTestCase):
     def setUp(self):
         super(EventManagerTestCase, self).setUp()
         # happens in Apr 5
-        self.create_event(
+        self.ev1 = self.create_event(
             title='ev1',
             start_date=tz_datetime(2014, 4, 5),
             publish_at=tz_datetime(2014, 4, 1)
         )
         # Apr 6 12:00 to Apr 7 9:00
-        self.create_event(
+        self.ev2 = self.create_event(
             title='ev2',
             start_date=tz_datetime(2014, 4, 6),
             end_date=tz_datetime(2014, 4, 7),
@@ -26,33 +26,33 @@ class EventManagerTestCase(EventBaseTestCase):
             publish_at=tz_datetime(2014, 4, 2)
         )
         # happens in Apr 7
-        self.create_event(
+        self.ev3 = self.create_event(
             title='ev3',
             start_date=tz_datetime(2014, 4, 7),
             publish_at=tz_datetime(2014, 4, 3)
         )
         # happens in Apr 8
-        self.create_event(
+        self.ev4 = self.create_event(
             title='ev4',
             start_date=tz_datetime(2014, 4, 8),
             publish_at=tz_datetime(2014, 4, 4)
         )
         # Apr 9 to Apr 15
-        self.create_event(
+        self.ev5 = self.create_event(
             title='ev5',
             start_date=tz_datetime(2014, 4, 9),
             end_date=tz_datetime(2014, 4, 15),
             publish_at=tz_datetime(2014, 4, 4)
         )
         # should happens in Apr 6 but is not published
-        self.create_event(
+        self.ev6 = self.create_event(
             title='ev6',
             start_date=tz_datetime(2014, 4, 6),
             publish_at=tz_datetime(2014, 4, 1),
             is_published=False
         )
         # happens in Apr 6
-        self.create_event(
+        self.ev7 = self.create_event(
             title='ev7',
             start_date=tz_datetime(2014, 4, 6),
             publish_at=tz_datetime(2014, 4, 1),
@@ -60,43 +60,48 @@ class EventManagerTestCase(EventBaseTestCase):
 
     def test_ongoing(self):
         now = tz_datetime(2014, 4, 7, 9, 30)
-        entries = Event.objects.ongoing(now)
-        self.assertQuerysetEqual(entries, ['ev2', 'ev3'], transform=str)
+        entries = [event.pk for event in Event.objects.ongoing(now)]
+        expected = [event.pk for event in [self.ev2, self.ev3]]
+        self.assertEqual(entries, expected)
 
     def test_published(self):
         now = tz_datetime(2014, 4, 1)
-        entries = Event.objects.published(now)
-        self.assertQuerysetEqual(entries, ['ev1', 'ev7'], transform=str)
+        entries = [event.pk for event in Event.objects.published(now)]
+        expected = [event.pk for event in [self.ev1, self.ev7]]
+        self.assertEqual(entries, expected)
 
     def test_future(self):
         now = tz_datetime(2014, 4, 7)
-        entries = Event.objects.future(now)
-        self.assertQuerysetEqual(
-            entries, ['ev2', 'ev3', 'ev4', 'ev5'], transform=str
-        )
+        entries = [event.pk for event in Event.objects.future(now)]
+        expected = [event.pk for event in
+                    [self.ev2, self.ev3, self.ev4, self.ev5]]
+        self.assertEqual(entries, expected)
 
     def test_archive(self):
         now = tz_datetime(2014, 4, 7)
-        entries = Event.objects.archive(now)
-        self.assertQuerysetEqual(entries, ['ev7', 'ev1'], transform=str)
+        entries = [event.pk for event in Event.objects.archive(now)]
+        expected = [event.pk for event in [self.ev7, self.ev1]]
+        self.assertEqual(entries, expected)
 
     def test_past(self):
         now = tz_datetime(2014, 4, 7)
         entries = Event.objects
         # the count=1 exclude ev1
-        self.assertQuerysetEqual(entries.past(1, now), ['ev7'], transform=str)
-        self.assertQuerysetEqual(
-            entries.past(5, now), ['ev7', 'ev1'], transform=str
-        )
+        actual1 = [event.pk for event in entries.past(1, now)]
+        expected1 = [self.ev7.pk]
+        self.assertEqual(actual1, expected1)
+        actual2 = [event.pk for event in entries.past(5, now)]
+        expected2 = [event.pk for event in [self.ev7, self.ev1]]
+        self.assertEqual(actual2, expected2)
 
     def test_upcoming(self):
         now = tz_datetime(2014, 4, 7)
         entries = Event.objects
         # the count=1 exclude ev1
-        self.assertQuerysetEqual(
-            entries.upcoming(1, now), ['ev2'], transform=str
-        )
-        self.assertQuerysetEqual(
-            entries.upcoming(5, now), ['ev2', 'ev3', 'ev4', 'ev5'],
-            transform=str
-        )
+        actual1 = [event.pk for event in entries.upcoming(1, now)]
+        self.assertEqual(actual1, [self.ev2.pk])
+
+        actual2 = [event.pk for event in entries.upcoming(5, now)]
+        expected2 = [event.pk for event in
+                     [self.ev2, self.ev3, self.ev4, self.ev5]]
+        self.assertEqual(actual2, expected2)

--- a/aldryn_events/tests/test_pages.py
+++ b/aldryn_events/tests/test_pages.py
@@ -163,7 +163,7 @@ class EventPagesTestCase(EventBaseTestCase):
         page.publish('en')
 
         # happens in Apr 5
-        self.create_event(
+        ev1 = self.create_event(
             title='ev1',
             start_date=tz_datetime(2014, 4, 5),
             publish_at=tz_datetime(2014, 4, 1)
@@ -183,7 +183,7 @@ class EventPagesTestCase(EventBaseTestCase):
             publish_at=tz_datetime(2014, 4, 3)
         )
         # happens in Apr 8
-        self.create_event(
+        ev4 = self.create_event(
             title='ev4',
             start_date=tz_datetime(2014, 4, 8),
             publish_at=tz_datetime(2014, 4, 4)
@@ -206,12 +206,14 @@ class EventPagesTestCase(EventBaseTestCase):
         )
         self.app_config.save()
 
-        self.assertQuerysetEqual(
-            context['ongoing_objects'], ['ev2', 'ev3'], transform=str
-        )
-        self.assertQuerysetEqual(
-            context['object_list'], ['ev4', 'ev1'], transform=str
-        )
+        actual_ongoing = [event.pk for event in context['ongoing_objects']]
+        expected_ongoing = [event.pk for event in [ev2, ev3]]
+        self.assertEqual(actual_ongoing, expected_ongoing)
+
+        actual_object_list = [event.pk for event in context['object_list']]
+        expected_object_list = [event.pk for event in [ev4, ev1]]
+        self.assertEqual(actual_object_list, expected_object_list)
+
         ongoing_list = PyQuery(response.content)('ul.ongoing-events')
         links = ongoing_list.find('h3 a')
         self.assertEqual(2, links.length)


### PR DESCRIPTION
Fix  issue #95.
This allows us to filter app configs correctly according to app config state and if it is app hooked check if page is published (for cases when aldryn-apphook-reload is not used on the project.
Also minor changes to templates to use get_title instead of unicode method, because then we can display handy app config information in forms, and still have control over title and translations.

Also should be applicable to #74.