### PR TITLE
Default config data migration: Create missing placeholders

### DIFF
--- a/aldryn_events/migrations/0016_auto_20150706_1655.py
+++ b/aldryn_events/migrations/0016_auto_20150706_1655.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations, transaction
+from django.db.models import get_model
+from django.db.utils import ProgrammingError
+from cms.models.fields import PlaceholderField
+
+
+def create_missing_placeholders(apps, schema_editor):
+    print 'data migration'
+    EventsConfig = apps.get_model('aldryn_events', 'EventsConfig')
+    Placeholder = apps.get_model('cms', 'Placeholder')
+    configs_qs = EventsConfig.objects.all()
+
+    try:
+        # to avoid the following error:
+        #   django.db.utils.InternalError: current transaction is aborted,
+        #   commands ignored until end of transaction block
+        # we need to cleanup or avoid that by making them atomic.
+        with transaction.atomic():
+            configs = list(configs_qs)
+    except ProgrammingError:
+        print 'exception'
+        # most likely we also need the latest Placeholder model
+        from cms.models import Placeholder
+        NewEventsConfig = get_model('aldryn_events.{0}'.format(EventsConfig.__name__))
+        with transaction.atomic():
+            configs = NewEventsConfig.objects.filter()
+
+    # get placeholders and their names
+    print configs
+    for cfg in configs:
+        for field in cfg._meta.fields:
+            if not field.__class__ == PlaceholderField:
+                # skip other fields.
+                continue
+            placeholder_name = field.name
+            placeholder_id_name = '{0}_id'.format(placeholder_name)
+            placeholder_id = getattr(cfg, placeholder_id_name)
+            if placeholder_id is not None:
+                # do not process if it has a reference to placeholder field.
+                continue
+            # since there is no placeholder - create it, we cannot use
+            # get_or_create because it can get placeholder from other config
+            PlaceholderField.pre_save(PlaceholderField(slotname=placeholder_name), cfg, False)
+            # new_placeholder = Placeholder.objects.create(slot=placeholder_name)
+            # setattr(cfg, placeholder_name, PlaceholderField(slotname=placeholder_name))
+            # print new_placeholder.id
+            # after we process all placeholder fields - save config,
+            # so that django can pick up them.
+            # IMPORTANT: Please don't move it outside of a loop, this would
+            # break this migration.
+            # cfg.save()
+    print 'data migration end'
+
+
+def noop_backwards(apps, schema_editor):
+    # doesn't make sense to do something here
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0003_auto_20140926_2347'),
+        ('aldryn_events', '0015_auto_20150702_1220'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_missing_placeholders, noop_backwards)
+    ]

--- a/aldryn_events/south_migrations/0025_create_placeholders_for_default_config.py
+++ b/aldryn_events/south_migrations/0025_create_placeholders_for_default_config.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models, connection, transaction
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+        from cms.models import Placeholder
+        # in order to fix this migration for sqlite3 we need to enable
+        # transaction autocommit, otherwise it is broken
+        if connection.vendor == 'sqlite':
+            transaction.set_autocommit(True)
+        EventsConfig = orm.EventsConfig
+
+        for cfg in EventsConfig.objects.all():
+            for field in cfg._meta.fields:
+                if field.__class__ != models.fields.related.ForeignKey:
+                    # skip not FK fields
+                    continue
+
+                if not (field.rel.to  == Placeholder or
+                        field.rel.to == orm['cms.Placeholder']):
+                    # skip other fields.
+                    continue
+
+                placeholder_name = field.name
+                placeholder_id_name = '{0}_id'.format(placeholder_name)
+                placeholder_id = getattr(cfg, placeholder_id_name)
+
+                if placeholder_id is not None:
+                    # do not process if it has a reference to placeholder field.
+                    continue
+
+                # since there is no placeholder - create it, we cannot use
+                # get_or_create because it can get placeholder from other config
+                new_placeholder = Placeholder.objects.create(
+                    slot=placeholder_name)
+                setattr(cfg, placeholder_id_name, new_placeholder.pk)
+
+            # after we process all placeholder fields - save config,
+            # so that django can pick up them.
+            cfg.save()
+
+    def backwards(self, orm):
+        # doesn't makes sense to add something here.
+        pass
+
+    models = {
+        u'aldryn_events.event': {
+            'Meta': {'ordering': "('start_date', 'start_time', 'end_date', 'end_time')", 'object_name': 'Event'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            'description': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'detail_link': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'enable_registration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'end_time': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
+            'event_coordinators': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['aldryn_events.EventCoordinator']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'publish_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'register_link': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'registration_deadline_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {}),
+            'start_time': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_events.eventcalendarplugin': {
+            'Meta': {'object_name': 'EventCalendarPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'aldryn_events.eventcoordinator': {
+            'Meta': {'object_name': 'EventCoordinator'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '80', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_events.eventlistplugin': {
+            'Meta': {'object_name': 'EventListPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'events': ('sortedm2m.fields.SortedManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['aldryn_events.Event']", 'null': 'True', 'blank': 'True'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "'standard'", 'max_length': '50'})
+        },
+        u'aldryn_events.eventsconfig': {
+            'Meta': {'object_name': 'EventsConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'unique': 'True', 'max_length': '100'}),
+            'placeholder_events_detail_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_detail_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_detail_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_list_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_list_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_list_top_ongoing': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_list_top_ongoing'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_registration': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_registration'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_registration_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_registration_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_sidebar': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_sidebar'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_events.eventsconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'EventsConfigTranslation', 'db_table': "u'aldryn_events_eventsconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_events.EventsConfig']"})
+        },
+        u'aldryn_events.eventtranslation': {
+            'Meta': {'unique_together': "[('language_code', 'slug'), (u'language_code', u'master')]", 'object_name': 'EventTranslation', 'db_table': "u'aldryn_events_event_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'event_images'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['filer.Image']"}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'location': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'location_lat': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'location_lng': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_events.Event']"}),
+            'short_description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "''", 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '150', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '150'})
+        },
+        u'aldryn_events.registration': {
+            'Meta': {'object_name': 'Registration'},
+            'address': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'company': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.Event']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '32'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'message': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'salutation': ('django.db.models.fields.CharField', [], {'default': "'mrs'", 'max_length': '5'})
+        },
+        u'aldryn_events.upcomingpluginitem': {
+            'Meta': {'object_name': 'UpcomingPluginItem'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'latest_entries': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '5'}),
+            'past_events': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "'standard'", 'max_length': '50'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_events']
+    symmetrical = True

--- a/aldryn_events/tests/base.py
+++ b/aldryn_events/tests/base.py
@@ -55,7 +55,6 @@ class EventBaseTestCase(TransactionTestCase):
         )
         self.template = get_cms_setting('TEMPLATES')[0][0]
         self.language = settings.LANGUAGES[0][0]
-        self.root_page = self.create_root_page()
 
     def tearDown(self):
         super(EventBaseTestCase, self).tearDown()
@@ -73,10 +72,14 @@ class EventBaseTestCase(TransactionTestCase):
         return root_page.reload()
 
     def create_base_pages(self):
+        root_page = self.create_root_page(
+            publication_date=tz_datetime(2014, 6, 8)
+        )
+
         page = api.create_page(
             title='Events en', template=self.template, language='en',
             slug='eventsapp', published=True,
-            parent=self.root_page,
+            parent=root_page,
             apphook='EventListAppHook',
             apphook_namespace=self.app_config.namespace,
             publication_date=tz_datetime(2014, 6, 8)

--- a/aldryn_events/tests/base.py
+++ b/aldryn_events/tests/base.py
@@ -55,6 +55,7 @@ class EventBaseTestCase(TransactionTestCase):
         )
         self.template = get_cms_setting('TEMPLATES')[0][0]
         self.language = settings.LANGUAGES[0][0]
+        self.root_page = self.create_root_page()
 
     def tearDown(self):
         super(EventBaseTestCase, self).tearDown()
@@ -72,13 +73,10 @@ class EventBaseTestCase(TransactionTestCase):
         return root_page.reload()
 
     def create_base_pages(self):
-        root_page = self.create_root_page(
-            publication_date=tz_datetime(2014, 6, 8)
-        )
         page = api.create_page(
             title='Events en', template=self.template, language='en',
             slug='eventsapp', published=True,
-            parent=root_page,
+            parent=self.root_page,
             apphook='EventListAppHook',
             apphook_namespace=self.app_config.namespace,
             publication_date=tz_datetime(2014, 6, 8)

--- a/aldryn_events/tests/test_plugins.py
+++ b/aldryn_events/tests/test_plugins.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from cms import api
+from cms.models import Placeholder
 from cms.utils.i18n import force_language
 from django.core.urlresolvers import reverse
 import mock
@@ -7,6 +8,7 @@ from aldryn_events.models import Event, EventsConfig
 from aldryn_events.tests.base import (
     EventBaseTestCase, tz_datetime
 )
+from aldryn_events.utils import namespace_is_apphooked
 
 
 def calendar_url(year, month, language):
@@ -16,6 +18,89 @@ def calendar_url(year, month, language):
             kwargs={'year': year, 'month': month}
         )
     return url
+
+
+class EventConfigPlaceholdersTestCase(EventBaseTestCase):
+
+    def setUp(self):
+        super(EventConfigPlaceholdersTestCase, self).setUp()
+        self.page_with_apphook = self.create_base_pages()
+
+    def test_event_config_placeholders_are_usable(self):
+        # make sure default config is apphooked to a page.
+        # FIXME: until migrations are not enabled and ensured to work with
+        # tests - this wont test the default adryn_events namespace =(
+        # though this test is (or at least it should be) pretty useful.
+        default_events_config = EventsConfig.objects.get_or_create(
+            namespace='aldryn_events')[0]
+        if not namespace_is_apphooked(default_events_config.namespace):
+            page = api.create_page(
+                title='default events config en', template=self.template,
+                language='en',
+                published=True,
+                parent=self.root_page,
+                apphook='EventListAppHook',
+                apphook_namespace=default_events_config.namespace,
+                publication_date=tz_datetime(2014, 6, 8)
+            )
+            api.create_title('de', 'default events config en', page)
+            page.publish('en')
+            page.publish('de')
+            page_with_default_config = page.reload()
+            # get some time for aldryn-apphook-reload to perform actions
+            with force_language('en'):
+                default_config_url = page_with_default_config.get_abolute_url()
+            self.client.get(default_config_url)
+
+        configs = EventsConfig.objects.all()
+        # this would be used to build unique value for text plugin
+        # namespace-lang-placeholder_name, which would be searched on the page.
+        plugin_content_raw = '{0}-{1}-{2}'
+        plugins_content = {}
+        for cfg in configs:
+            cfg_placehodlers = [field for field in cfg._meta.fields
+                                if field.__class__ == Placeholder]
+            placeholders_names = [placeholder.name for placeholder in
+                                  cfg_placehodlers]
+            # make sure that we have an empty list to store plugins content
+            plugins_content[cfg] = []
+            for placeholder_name in placeholders_names:
+                placeholder_instance = getattr(cfg, placeholder_name)
+                self.assertNotEqual(type(placeholder_instance), type(None))
+                plugin_text = plugin_content_raw.format(
+                    cfg.namespace, 'en', placeholder_name)
+                plugin = api.add_plugin(
+                    placeholder_instance, 'TextPlugin', 'en',
+                    body=plugin_text)
+                # track other namespaces plugin content to check
+                # their uniqueness
+                plugins_content[cfg].append(plugin_text)
+
+        # test EventsConfig placeholder content if it is attached to a page
+        skipped = []
+        for cfg in configs:
+            if not namespace_is_apphooked(cfg.namespace):
+                skipped.append(cfg)
+                continue
+
+            with force_language('en'):
+                apphook_url = reverse('{0}:events_list'.format(cfg.namespace))
+            response = self.client.get(apphook_url)
+
+            # test own content
+            for text in plugins_content[cfg]:
+                self.assertIn(response, text)
+
+            # make sure other namespace plugins are not leaked
+            other_configs = [config for config in plugins_content.keys()
+                             if config is not cfg]
+            all_other_namespace_plugins_text = [
+                text for other_config in other_configs
+                for text in plugins_content[other_config]]
+            for other_plugins_text in all_other_namespace_plugins_text:
+                self.assertNotIn(response, other_plugins_text)
+        # make sure that we tested at least one config
+        self.assertNotEqual(configs.count(), len(skipped))
 
 
 class EventPluginsTestCase(EventBaseTestCase):


### PR DESCRIPTION
Since we have a data migration that creates default event config and a schema migration that adds a placeholderFields to it we need to create those placeholder fields, otherwise users cannot use them until at least one save either through admin interface or via shell. 

This solves that issue by creating missing placeholders. Also should cover cases if placeholder migration were applied and user had more that one config.

Should not affect existing placeholders.