### PR TITLE
Fix event list view for year/month/day if event was created for past.

### DIFF
--- a/aldryn_events/tests/test_views.py
+++ b/aldryn_events/tests/test_views.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import datetime
 
 from django.core.urlresolvers import reverse
 from django.utils.translation import override
 
 from cms import api
+from cms.utils.i18n import force_language
 
 from aldryn_events.models import Event
 
@@ -32,10 +34,84 @@ class TestEventViews(EventBaseTestCase):
             page_url = page.get_absolute_url()
         self.client.get(page_url)
 
-    def test_event_list_view(self):
+    def get_past_date(self, days=2):
+        now_date = datetime.datetime.now().date()
+        return now_date - datetime.timedelta(days=days)
+
+    def get_new_past_event_data(
+            self, start_date=None, end_date=None, arg_list=None):
+        if start_date is None:
+            start_date = self.get_past_date()
+        if end_date is None:
+            end_date = self.get_past_date()
+        if arg_list is None:
+            arg_list = ('day', 'month', 'year')
+        dates = {
+            'start_date': start_date,
+            'end_date': end_date,
+        }
+        event_data = self.make_default_values_with_new_dates(
+            date_values=dates)
+        kwargs = {}
+        for att_name in arg_list:
+            kwargs[att_name] = getattr(start_date, att_name)
+        return event_data, kwargs
+
+    def test_event_list_view_returns_200(self):
         url = reverse("{0}:events_list".format(self.app_config.namespace))
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
+
+    def test_event_list_by_day_past_event_1_day_long(self):
+        """
+        Regression test case for checking that if event was created
+        today but for past day it is still displayed on list view for day
+        """
+        event_data, kwargs = self.get_new_past_event_data()
+        with force_language('en'):
+            event = self.create_event(**event_data)
+            event_url = event.get_absolute_url()
+            view_url = reverse('{0}:events_list-by-day'.format(
+                self.app_config.namespace), kwargs=kwargs)
+        response = self.client.get(view_url)
+        self.assertContains(response, event.get_title())
+        self.assertContains(response, event_url)
+
+    def test_event_list_by_month_past_event_1_day_long(self):
+        """
+        Regression test case for checking that if event was created
+        today but for past date it is still displayed on month list view
+        """
+        # make it previous month or so
+        start_date = end_date = self.get_past_date(35)
+        event_data, kwargs = self.get_new_past_event_data(
+            start_date, end_date, arg_list=('month', 'year'))
+        with force_language('en'):
+            event = self.create_event(**event_data)
+            event_url = event.get_absolute_url()
+            view_url = reverse('{0}:events_list-by-month'.format(
+                self.app_config.namespace), kwargs=kwargs)
+        response = self.client.get(view_url)
+        self.assertContains(response, event.get_title())
+        self.assertContains(response, event_url)
+
+    def test_event_list_by_year_past_event_1_day_long(self):
+        """
+        Regression test case for checking that if event was created
+        today but for past date it is still displayed on month list view
+        """
+        # make it previous year or so
+        start_date = end_date = self.get_past_date(366)
+        event_data, kwargs = self.get_new_past_event_data(
+            start_date, end_date, arg_list=('year',))
+        with force_language('en'):
+            event = self.create_event(**event_data)
+            event_url = event.get_absolute_url()
+            view_url = reverse('{0}:events_list-by-year'.format(
+                self.app_config.namespace), kwargs=kwargs)
+        response = self.client.get(view_url)
+        self.assertContains(response, event.get_title())
+        self.assertContains(response, event_url)
 
     def test_event_detail_view(self):
         with override("en"):

--- a/aldryn_events/views.py
+++ b/aldryn_events/views.py
@@ -89,21 +89,15 @@ class EventListView(AppConfigMixin, NavigationMixin, ListView):
             if year and month and day:
                 year, month, day = map(int, [year, month, day])
                 _date = date(year, month, day)
-                last_datetime = datetime(
-                    year, month, day, 23, 59, 59, tzinfo=tz
-                )
 
                 qs = qs.filter(
                     Q(start_date=_date, end_date__isnull=True) |
                     Q(start_date__lte=_date, end_date__gte=_date)
-                ).published(last_datetime)
+                ).published()
             elif year and month:
                 year, month = map(int, [year, month])
                 date_start = date(year, month, 1)
                 date_end = date_start + relativedelta(months=1, days=-1)
-                last_datetime = datetime(
-                    tzinfo=tz, *(date_end.timetuple()[:3])
-                ) + relativedelta(days=1, minutes=-1)
 
                 qs = qs.filter(
                     Q(start_date__range=(date_start, date_end),
@@ -114,14 +108,11 @@ class EventListView(AppConfigMixin, NavigationMixin, ListView):
                       end_date__range=(date_start, date_end)) |
                     Q(start_date__lt=date_start,
                       end_date__gte=date_end)
-                ).published(last_datetime)
+                ).published()
             else:
                 year = int(year)
                 date_start = date(year, 1, 1)
                 date_end = date_start + relativedelta(years=1, days=-1)
-                last_datetime = datetime(
-                    tzinfo=tz, *(date_end.timetuple()[:3])
-                ) + relativedelta(days=1, minutes=-1)
 
                 qs = qs.filter(
                     Q(start_date__range=(date_start, date_end),
@@ -130,8 +121,7 @@ class EventListView(AppConfigMixin, NavigationMixin, ListView):
                       end_date__lte=date_end) |
                     Q(start_date__lt=date_start,
                       end_date__range=(date_start, date_end))
-                ).published(last_datetime)
-
+                ).published()
         else:
             if self.archive:
                 qs = qs.archive()


### PR DESCRIPTION
There were an issue if event was created in present for past, it was not displayed because the published filtering was also checked against publicate_at which by default is now() but filtering was performed against not correctly formed date. Also that may have had impact for future events.