### PR TITLE
Move registration to content

### DIFF
--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
@@ -6,9 +6,10 @@
     <div class="aldryn-events-detail">
         {% include "aldryn_events/includes/event.html" with detail_view="true" %}
     </div>
+    {% if event.enable_registration %}
+        {% include "aldryn_events/includes/registration.html" %}
+    {% endif %}{% endblock events_content %}
     {% render_placeholder view.config.placeholder_events_detail_bottom %}
-{% endblock events_content %}
-
 {% block events_footer %}
     <div class="aldryn-events-pager">
         <ul class="pager">
@@ -64,10 +65,6 @@
                 <p class="detail-link">
                     <a href="{{ event.detail_link }}">{% trans "More information" %}</a>
                 </p>
-            {% endif %}
-
-            {% if event.enable_registration %}
-                {% include "aldryn_events/includes/registration.html" %}
             {% endif %}
         </div>
     </div>

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
@@ -8,8 +8,9 @@
     </div>
     {% if event.enable_registration %}
         {% include "aldryn_events/includes/registration.html" %}
-    {% endif %}{% endblock events_content %}
+    {% endif %}
     {% render_placeholder view.config.placeholder_events_detail_bottom %}
+{% endblock events_content %}
 {% block events_footer %}
     <div class="aldryn-events-pager">
         <ul class="pager">

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/events_detail.html
@@ -11,6 +11,7 @@
     {% endif %}
     {% render_placeholder view.config.placeholder_events_detail_bottom %}
 {% endblock events_content %}
+
 {% block events_footer %}
     <div class="aldryn-events-pager">
         <ul class="pager">


### PR DESCRIPTION
It makes more sense to move the registration process to the context of the content rather than underneath the pagination