### PR TITLE
Fix issue with models.set_event_slug if no translations present.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.0.X (XXXX-XX-XX)
+------------------
+
+* Fix for models.set_event_slug unhandled exception (recover deleted event)
+
 1.0.5 (2015-09-09)
 ------------------
 

--- a/aldryn_events/models.py
+++ b/aldryn_events/models.py
@@ -311,7 +311,8 @@ def set_event_slug(instance, **kwargs):
     translation = None
     try:
         if not instance.slug:
-            translation = instance.get_translation(instance.get_current_language())
+            translation = instance.get_translation(
+                instance.get_current_language())
     except ObjectDoesNotExist:
         pass
     else:

--- a/aldryn_events/models.py
+++ b/aldryn_events/models.py
@@ -7,7 +7,7 @@ from django.utils.importlib import import_module
 from distutils.version import LooseVersion
 
 from django import get_version
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -306,8 +306,18 @@ class Event(TranslationHelperMixin, TranslatableModel):
 
 
 def set_event_slug(instance, **kwargs):
-    if not instance.slug:
-        translation = instance.get_translation(instance.get_current_language())
+    # avoid accessing slug if no translations present. we cannot fix missing
+    # translations from here, either they are not restored or corrupted.
+    translation = None
+    try:
+        if not instance.slug:
+            translation = instance.get_translation(instance.get_current_language())
+    except ObjectDoesNotExist:
+        pass
+    else:
+        if not translation:
+            return
+
         unique_slugify(
             instance=instance.get_translation(instance.get_current_language()),
             value=translation.title or uuid4().hex[:8],

--- a/aldryn_events/tests/test_events.py
+++ b/aldryn_events/tests/test_events.py
@@ -263,3 +263,37 @@ class EventTestCase(EventBaseTestCase):
         )
         event.save()
         self.assertEqual(event.slug, 'gotchaa')
+
+    def test_event_save_does_not_crashes_if_no_translations(self):
+        event = Event(
+            title='show me the slug', slug='gotchaa',
+            start_date=tz_datetime(2015, 2, 4),
+            app_config=self.app_config
+        )
+        event.save()
+        self.assertEqual(event.slug, 'gotchaa')
+        # delete translations, emulate data corruption or recover process
+        # when there is no translations recovered yet.
+        translations = event.translations.all()
+        translations.delete()
+        self.assertEqual(event.translations.count(), 0)
+        # Refresh event from db and fail with exception if there are errors
+        # in models.set_event_slug
+        event = Event.objects.get(pk=event.pk)
+        event.save()
+        # create a translation to to test that models.set_event_slug still
+        # picks up and does the correct thing
+        event.translations.create(
+            title='test_event_save_does_not_crashes_if_no_translations',
+            language_code='en')
+        event = Event.objects.get(pk=event.pk)
+        event.set_current_language('en')
+        # ensure slug is not set.
+        if event.slug:
+            self.assertTrue(False, msg='Slug is not empty, something wrong..')
+        # recreate slug
+        event.save()
+        self.assertEqual(event.title,
+                         'test_event_save_does_not_crashes_if_no_translations')
+        self.assertEqual(event.slug,
+                         'test_event_save_does_not_crashes_if_no_translations')


### PR DESCRIPTION
There was a bug related to aldryn-reversion, when recovering deleted event it was failing because translations were not recovered at the moment of event.save, and due to post save signal processing set_event_slug was triggered, which did not checked if there is a translations which leaded to a failure.

PR introduces:
* fix for this issue
* regression test case