### PR TITLE
Fix 500 error if EventsConfig for apphooked page was deleted. Display message.

### DIFF
--- a/aldryn_events/admin.py
+++ b/aldryn_events/admin.py
@@ -19,7 +19,7 @@ from parler.admin import TranslatableAdmin
 from aldryn_translation_tools.admin import AllTranslationsMixin
 
 from .cms_appconfig import EventsConfig
-from .models import Event, EventCoordinator, Registration, EventsConfig
+from .models import Event, EventCoordinator, Registration
 from .forms import EventAdminForm
 
 
@@ -89,8 +89,10 @@ class RegistrationAdmin(TablibAdmin if TablibAdmin is not None
     date_hierarchy = 'created_at'
 
 
-class EventConfigAdmin(AllTranslationsMixin, PlaceholderAdminMixin,
-                       BaseAppHookConfig, TranslatableAdmin):
+class EventConfigAdmin(VersionedPlaceholderAdminMixin,
+                       AllTranslationsMixin,
+                       BaseAppHookConfig,
+                       TranslatableAdmin):
     def get_config_fields(self):
         return ('app_title', 'latest_first', 'config.show_ongoing_first', )
 

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
@@ -4,7 +4,7 @@
     {% if namespace_error %}
         {% if request.user.is_staff or request.user.is_superuser %}
           <div class="events-calendar events-calendar-error">
-              <p>{{ namespace_error }}</p>
+              <p class="config-errors">{{ namespace_error }}</p>
           </div>
         {% endif %}
     {% else %}

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
@@ -3,9 +3,9 @@
 {% block events_calendar %}
     {% if namespace_error %}
         {% if request.user.is_staff or request.user.is_superuser %}
-          <div class="events-calendar events-calendar-error">
-              <p class="config-errors">{{ namespace_error }}</p>
-          </div>
+            <div class="events-calendar events-calendar-error">
+                <p class="config-errors">{{ namespace_error }}</p>
+            </div>
         {% endif %}
     {% else %}
         <div class="events-calendar js-events-calendar"

--- a/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/bootstrap3/templates/aldryn_events/includes/calendar.html
@@ -1,19 +1,27 @@
 {% load i18n static sekizai_tags apphooks_config_tags %}
 
 {% block events_calendar %}
-    <div class="events-calendar js-events-calendar"
-        data-url="{% namespace_url 'get-calendar-dates' namespace=calendar_tag.namespace %}"
-        data-pk="{{ plugin.instance.pk }}"
-        data-error="{% trans 'There was a problem accessing the calendar, please try again.'|escapejs %}">
+    {% if namespace_error %}
+        {% if request.user.is_staff or request.user.is_superuser %}
+          <div class="events-calendar events-calendar-error">
+              <p>{{ namespace_error }}</p>
+          </div>
+        {% endif %}
+    {% else %}
+        <div class="events-calendar js-events-calendar"
+            data-url="{% namespace_url 'get-calendar-dates' namespace=calendar_tag.namespace %}"
+            data-pk="{{ plugin.instance.pk }}"
+            data-error="{% trans 'There was a problem accessing the calendar, please try again.'|escapejs %}">
 
-        <h3>{{ calendar_tag.label }}</h3>
-        <p class="controls clearfix">
-            <a href="#" class="pull-left js-trigger" data-direction="previous">{% trans "Previous month" %}</a>
-            <a href="{% namespace_url 'events_list' namespace=calendar_tag.namespace %}">{% trans "Today" %}</a>
-            <a href="#" class="pull-right js-trigger" data-direction="next">{% trans "Next month" %}</a>
-        </p>
-        {% include "aldryn_events/includes/calendar_table.html" %}
-    </div>
+            <h3>{{ calendar_tag.label }}</h3>
+            <p class="controls clearfix">
+                <a href="#" class="pull-left js-trigger" data-direction="previous">{% trans "Previous month" %}</a>
+                <a href="{% namespace_url 'events_list' namespace=calendar_tag.namespace %}">{% trans "Today" %}</a>
+                <a href="#" class="pull-right js-trigger" data-direction="next">{% trans "Next month" %}</a>
+            </p>
+            {% include "aldryn_events/includes/calendar_table.html" %}
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% addtoblock "js" %}<script src="{% static 'js/addons/cl.events.js' %}"></script>{% endaddtoblock %}

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
@@ -29,11 +29,19 @@
 </script>
 {% endaddtoblock %}
 <div class="events-calendar">
-  <h3>{{ calendar_tag.label }}</h3>
-  <p class="controls">
-    <a href="" class="back">{% trans "Previous month" %}</a>
-    <a href="" class="next">{% trans "Next month" %}</a>
-  </p>
-  {% include "aldryn_events/includes/calendar_table.html" %}
+    {% if namespace_error %}
+        {% if request.user.is_staff or request.user.is_superuser %}
+          <div class="events-calendar events-calendar-error">
+              <p>{{ namespace_error }}</p>
+          </div>
+        {% endif %}
+    {% else %}
+        <h3>{{ calendar_tag.label }}</h3>
+        <p class="controls">
+            <a href="" class="back">{% trans "Previous month" %}</a>
+            <a href="" class="next">{% trans "Next month" %}</a>
+        </p>
+    {% include "aldryn_events/includes/calendar_table.html" %}
+  {% endif %}
 </div>
 {% endblock %}

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
@@ -31,9 +31,9 @@
 <div class="events-calendar">
     {% if namespace_error %}
         {% if request.user.is_staff or request.user.is_superuser %}
-          <div class="events-calendar events-calendar-error">
-              <p class="config-errors">{{ namespace_error }}</p>
-          </div>
+            <div class="events-calendar events-calendar-error">
+                <p class="config-errors">{{ namespace_error }}</p>
+            </div>
         {% endif %}
     {% else %}
         <h3>{{ calendar_tag.label }}</h3>

--- a/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
+++ b/aldryn_events/boilerplates/legacy/templates/aldryn_events/includes/calendar.html
@@ -32,7 +32,7 @@
     {% if namespace_error %}
         {% if request.user.is_staff or request.user.is_superuser %}
           <div class="events-calendar events-calendar-error">
-              <p>{{ namespace_error }}</p>
+              <p class="config-errors">{{ namespace_error }}</p>
           </div>
         {% endif %}
     {% else %}


### PR DESCRIPTION
Fix 500 error (raised in calendar template tag) if config was deleted.
* ensure that no events would be resolved for not existing config,
* display error message to staff and superuser