### PR TITLE
Fix plugin forms app config mixin to be more defensive

### DIFF
--- a/aldryn_events/cms_plugins.py
+++ b/aldryn_events/cms_plugins.py
@@ -9,7 +9,7 @@ from django.utils.translation import (
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from .utils import build_calendar, namespace_is_apphooked
+from .utils import build_calendar, is_valid_namespace
 from .models import (
     UpcomingPluginItem, Event, EventListPlugin, EventCalendarPlugin
 )
@@ -45,7 +45,7 @@ class UpcomingPlugin(CMSPluginBase):
         context['instance'] = instance
         # check if we can reverse list view for configured namespace
         # if no prepare a message to admin users.
-        if not namespace_is_apphooked(namespace):
+        if not is_valid_namespace(namespace):
             # add message, should be properly handled in template
             context['plugin_configuration_error'] = NO_APPHOOK_ERROR_MESSAGE
             return context
@@ -85,7 +85,7 @@ class EventListCMSPlugin(CMSPluginBase):
         namespace = instance.app_config_id and instance.app_config.namespace
         # check if we can reverse list view for configured namespace
         # if no prepare a message to admin users.
-        if not namespace_is_apphooked(namespace):
+        if not is_valid_namespace(namespace):
             # add message, should be properly handled in template
             context['plugin_configuration_error'] = NO_APPHOOK_ERROR_MESSAGE
             return context
@@ -116,7 +116,7 @@ class CalendarPlugin(CMSPluginBase):
         # # check if we can reverse list view for configured namespace
         # # if no prepare a message to admin users.
         namespace = instance.app_config_id and instance.app_config.namespace
-        if not namespace_is_apphooked(namespace):
+        if not is_valid_namespace(namespace):
             # add message, should be properly handled in template
             context['plugin_configuration_error'] = NO_APPHOOK_ERROR_MESSAGE
             return context

--- a/aldryn_events/cms_wizards.py
+++ b/aldryn_events/cms_wizards.py
@@ -15,7 +15,7 @@ from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import EventsConfig
 from .models import Event
-from .utils import namespace_is_apphooked
+from .utils import is_valid_namespace
 
 
 class EventWizard(Wizard):
@@ -29,7 +29,7 @@ class EventWizard(Wizard):
         """
         # No one can create an Event, if there is no app_config yet.
         configs = EventsConfig.objects.all()
-        if not configs or not any([namespace_is_apphooked(config.namespace)
+        if not configs or not any([is_valid_namespace(config.namespace)
                                    for config in configs]):
             return False
         # Ensure user has permission to create event.
@@ -67,7 +67,7 @@ class CreateEventForm(BaseFormMixin, TranslatableModelForm):
         # check if app config is apphooked
         app_configs = [app_config
                        for app_config in app_configs
-                       if namespace_is_apphooked(app_config.namespace)]
+                       if is_valid_namespace(app_config.namespace)]
         if len(app_configs) == 1:
             self.fields['app_config'].widget = forms.HiddenInput()
             self.fields['app_config'].initial = app_configs[0].pk

--- a/aldryn_events/forms.py
+++ b/aldryn_events/forms.py
@@ -19,7 +19,7 @@ from .models import (
 )
 from .utils import (
     send_user_confirmation_email, send_manager_confirmation_email,
-    namespace_is_apphooked,
+    is_valid_namespace,
 )
 
 
@@ -135,7 +135,7 @@ class AppConfigPluginFormMixin(object):
 
         published_configs_pks = [
             config.pk for config in available_configs
-            if namespace_is_apphooked(config.namespace)]
+            if is_valid_namespace(config.namespace)]
 
         self.fields['app_config'].queryset = available_configs.filter(
             pk__in=published_configs_pks)
@@ -169,7 +169,9 @@ class AppConfigPluginFormMixin(object):
         # to reverse, in case of success that would mean that the app_config
         # is correct and can be used.
         data = super(AppConfigPluginFormMixin, self).clean()
-        if not namespace_is_apphooked(data['app_config'].namespace):
+        app_config = data.get('app_config', None)
+        namespace = getattr(app_config, 'namespace', None)
+        if not is_valid_namespace(namespace):
             raise ValidationError(
                 _('Seems that selected Job config is not plugged to any page, '
                   'or maybe that page is not published.'

--- a/aldryn_events/forms.py
+++ b/aldryn_events/forms.py
@@ -164,7 +164,7 @@ class AppConfigPluginFormMixin(object):
     def clean(self):
         # since namespace is not a unique thing we need to validate it
         # additionally because it is possible that there is a page with same
-        # namespace as a jobs config but which is using other app_config,
+        # namespace as a events config but which is using other app_config,
         # which also would lead to same 500 error. The easiest way is to try
         # to reverse, in case of success that would mean that the app_config
         # is correct and can be used.
@@ -173,9 +173,9 @@ class AppConfigPluginFormMixin(object):
         namespace = getattr(app_config, 'namespace', None)
         if not is_valid_namespace(namespace):
             raise ValidationError(
-                _('Seems that selected Job config is not plugged to any page, '
-                  'or maybe that page is not published.'
-                  'Please select Job config that is being used.'),
+                _('Seems that selected Event config is not plugged to any '
+                  'page, or maybe that page is not published.'
+                  'Please select Event config that is being used.'),
                 code='invalid')
         return data
 

--- a/aldryn_events/tests/test_plugins.py
+++ b/aldryn_events/tests/test_plugins.py
@@ -12,7 +12,7 @@ from aldryn_events.models import Event, EventsConfig
 from aldryn_events.tests.base import (
     EventBaseTestCase, tz_datetime
 )
-from aldryn_events.utils import namespace_is_apphooked
+from aldryn_events.utils import is_valid_namespace
 
 
 def calendar_url(year, month, language, namespace):
@@ -37,7 +37,7 @@ class EventConfigPlaceholdersTestCase(EventBaseTestCase):
         # though this test is (or at least it should be) pretty useful.
         default_events_config = EventsConfig.objects.get_or_create(
             namespace='aldryn_events')[0]
-        if not namespace_is_apphooked(default_events_config.namespace):
+        if not is_valid_namespace(default_events_config.namespace):
             page = api.create_page(
                 title='default events config en', template=self.template,
                 language='en',
@@ -83,7 +83,7 @@ class EventConfigPlaceholdersTestCase(EventBaseTestCase):
         # test EventsConfig placeholder content if it is attached to a page
         skipped = []
         for cfg in configs:
-            if not namespace_is_apphooked(cfg.namespace):
+            if not is_valid_namespace(cfg.namespace):
                 skipped.append(cfg)
                 continue
 

--- a/aldryn_events/utils.py
+++ b/aldryn_events/utils.py
@@ -243,7 +243,7 @@ def date_or_datetime(d, t):
         return None
 
 
-def namespace_is_apphooked(namespace):
+def is_valid_namespace(namespace):
     """
     Check if provided namespace has an app-hooked page.
     Returns True or False.


### PR DESCRIPTION
Fixes 500 error in ``CMS 3.2`` when creating plugin and events config (which would be then selected) at the same time.

* Be more defensive while getting data.
* Minor refactoring of utility function.