### PR TITLE
Fix Django migrations warnings

### DIFF
--- a/aldryn_events/migrations/0020_m2m_remove_null.py
+++ b/aldryn_events/migrations/0020_m2m_remove_null.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import sortedm2m.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_events', '0019_auto_20150804_2232'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='event_coordinators',
+            field=models.ManyToManyField(to='aldryn_events.EventCoordinator', verbose_name='event coordinators', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='eventlistplugin',
+            name='events',
+            field=sortedm2m.fields.SortedManyToManyField(help_text=None, to='aldryn_events.Event', blank=True),
+        ),
+    ]

--- a/aldryn_events/migrations/0021_eventcoordinator_fk_to_one_to_one.py
+++ b/aldryn_events/migrations/0021_eventcoordinator_fk_to_one_to_one.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_events', '0020_m2m_remove_null'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventcoordinator',
+            name='user',
+            field=models.OneToOneField(null=True, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user'),
+        ),
+    ]

--- a/aldryn_events/models.py
+++ b/aldryn_events/models.py
@@ -143,8 +143,7 @@ class Event(TranslatedAutoSlugifyMixin,
         _('allow registration until'), null=True, blank=True, default=None
     )
     event_coordinators = models.ManyToManyField(
-        'EventCoordinator', verbose_name=_('event coordinators'),
-        null=True, blank=True
+        'EventCoordinator', verbose_name=_('event coordinators'), blank=True
     )
     description = PlaceholderField(
         'aldryn_events_event_description', verbose_name=_('description')
@@ -453,7 +452,7 @@ class EventListPlugin(BaseEventPlugin):
         default=STANDARD,
         max_length=50
     )
-    events = SortedManyToManyField(Event, blank=True, null=True)
+    events = SortedManyToManyField(Event, blank=True)
 
     def __str__(self):
         return force_text(self.pk)

--- a/aldryn_events/models.py
+++ b/aldryn_events/models.py
@@ -313,12 +313,11 @@ class EventCoordinator(models.Model):
 
     name = models.CharField(max_length=200, blank=True)
     email = models.EmailField(max_length=80, blank=True)
-    user = models.ForeignKey(
+    user = models.OneToOneField(
         to=getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
         verbose_name=_('user'),
         null=True,
         blank=True,
-        unique=True
     )
 
     def __str__(self):

--- a/aldryn_events/south_migrations/0027_eventcoordinator_fk_to_one_to_one.py
+++ b/aldryn_events/south_migrations/0027_eventcoordinator_fk_to_one_to_one.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'EventCoordinator.user'
+        db.alter_column(u'aldryn_events_eventcoordinator', 'user_id', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['auth.User'], unique=True, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'EventCoordinator.user'
+        db.alter_column(u'aldryn_events_eventcoordinator', 'user_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], unique=True, null=True))
+
+    models = {
+        u'aldryn_events.event': {
+            'Meta': {'ordering': "(u'start_date', u'start_time', u'end_date', u'end_time')", 'object_name': 'Event'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            'description': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'detail_link': ('django.db.models.fields.URLField', [], {'default': "u''", 'max_length': '200', 'blank': 'True'}),
+            'enable_registration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'end_time': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
+            'event_coordinators': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['aldryn_events.EventCoordinator']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'publish_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'register_link': ('django.db.models.fields.URLField', [], {'default': "u''", 'max_length': '200', 'blank': 'True'}),
+            'registration_deadline_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {}),
+            'start_time': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_events.eventcalendarplugin': {
+            'Meta': {'object_name': 'EventCalendarPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'aldryn_events.eventcoordinator': {
+            'Meta': {'object_name': 'EventCoordinator'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '80', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_events.eventlistplugin': {
+            'Meta': {'object_name': 'EventListPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'events': ('sortedm2m.fields.SortedManyToManyField', [], {'to': u"orm['aldryn_events.Event']", 'symmetrical': 'False', 'blank': 'True'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "u'standard'", 'max_length': '50'})
+        },
+        u'aldryn_events.eventsconfig': {
+            'Meta': {'object_name': 'EventsConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latest_first': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'unique': 'True', 'max_length': '100'}),
+            'placeholder_events_detail_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_detail_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_detail_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_detail_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_list_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_list_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_list_top_ongoing': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_list_top_ongoing'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_registration': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_registration'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_registration_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_registration_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_sidebar': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_sidebar'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_events_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_events_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_events.eventsconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'EventsConfigTranslation', 'db_table': "u'aldryn_events_eventsconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '234', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_events.EventsConfig']"})
+        },
+        u'aldryn_events.eventtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'slug'), (u'language_code', u'master')]", 'object_name': 'EventTranslation', 'db_table': "u'aldryn_events_event_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'event_images'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['filer.Image']"}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'location': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'location_lat': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'location_lng': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_events.Event']"}),
+            'short_description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '150', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '150'})
+        },
+        u'aldryn_events.registration': {
+            'Meta': {'object_name': 'Registration'},
+            'address': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'company': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.Event']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '32'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'message': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '20', 'blank': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '20', 'blank': 'True'}),
+            'salutation': ('django.db.models.fields.CharField', [], {'default': "u'mrs'", 'max_length': '5'})
+        },
+        u'aldryn_events.upcomingpluginitem': {
+            'Meta': {'object_name': 'UpcomingPluginItem'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_events.EventsConfig']"}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'latest_entries': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '5'}),
+            'past_events': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "u'standard'", 'max_length': '50'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_events']


### PR DESCRIPTION
Minor changes to models schema to fix Django migrations warnings as reported by `manage.py migrate --list`.

Django will create one or two more automatic migrations if you ask it. It is because underneath the `max_length` of the `EmailField` has changed and probably your language settings do not match defaults. It's up to the user if he really wants to create/apply those in his project.