### PR TITLE
Fix tests for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,16 @@ env:
     #   PY strategy: do not test 3.3 at all.
     #   FE strategy: only test on Django/CMS3.2 combinations, but place tests on
     #                different Python ENVs if possible.
-    # NOTE: FE-TESTS ARE DISABLED UNTIL THEY ARE FIXED FOR CMS 3.2
     - TOXENV=flake8
-    - TOXENV=py27-dj18-cms32
+    - TOXENV=py27-dj18-cms32-fe
     - TOXENV=py27-dj18-cms31
-    - TOXENV=py27-dj17-cms32
+    - TOXENV=py27-dj17-cms32-fe
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30
     - TOXENV=py27-dj16-cms32
     - TOXENV=py27-dj16-cms31
     - TOXENV=py27-dj16-cms30
-    - TOXENV=py26-dj16-cms32
+    - TOXENV=py26-dj16-cms32-fe
     - TOXENV=py26-dj16-cms31
     - TOXENV=py26-dj16-cms30
 

--- a/aldryn_events/tests/frontend/integration/pages/page.events.crud.js
+++ b/aldryn_events/tests/frontend/integration/pages/page.events.crud.js
@@ -4,36 +4,37 @@
  */
 
 'use strict';
-/* global by, element, expect */
+/* global browser, by, element, expect */
 
 // #############################################################################
 // INTEGRATION TEST PAGE OBJECT
 
-var cmsProtractorHelper = require('cms-protractor-helper');
-
-var eventsPage = {
+var page = {
     site: 'http://127.0.0.1:8000/en/',
 
     // log in, log out
     editModeLink: element(by.css('.inner a[href="/?edit"]')),
-    usernameInput: element(by.id('id_cms-username')),
-    passwordInput: element(by.id('id_cms-password')),
-    loginButton: element(by.css('.cms_form-login input[type="submit"]')),
-    userMenus: element.all(by.css('.cms_toolbar-item-navigation > li > a')),
+    usernameInput: element(by.id('id_username')),
+    passwordInput: element(by.id('id_password')),
+    loginButton: element(by.css('input[type="submit"]')),
+    userMenus: element.all(by.css('.cms-toolbar-item-navigation > li > a')),
 
     // adding new page
+    modalCloseButton: element(by.css('.cms-modal-close')),
     userMenuDropdown: element(by.css(
-        '.cms_toolbar-item-navigation-hover')),
+        '.cms-toolbar-item-navigation-hover')),
     administrationOptions: element.all(by.css(
-        '.cms_toolbar-item-navigation a[href="/en/admin/"]')),
-    sideMenuIframe: element(by.css('.cms_sideframe-frame iframe')),
+        '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
+    sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
+    addConfigsButton: element(by.css('.object-tools .addlink')),
     addPageLink: element(by.css('.sitemap-noentry .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col1 [href*="preview/"]')),
-    testLink: element(by.css('.selected a')),
+    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    testLink: element(by.cssContainingText('a', 'Test')),
+    sideFrameClose: element(by.css('.cms-sideframe-close')),
 
     // adding new apphook config
     eventsConfigsLink: element(by.css('.model-eventsconfig > th > a')),
@@ -43,24 +44,27 @@ var eventsPage = {
     applicationTitleInput: element(by.id('id_app_title')),
 
     // adding new event
+    breadcrumbs: element(by.css('.breadcrumbs')),
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     addEventLink: element(by.css('.model-event .addlink')),
+    editEventLink: element(by.css('.model-event .changelink')),
     startDateLinks: element.all(by.css('.field-start_date a')),
     startTimeLinks: element.all(by.css(
         '.field-start_time > .datetimeshortcuts > a')),
     endDateInput: element(by.id('id_end_date')),
     endTimeInput: element(by.id('id_end_time')),
     successNotification: element(by.css('.messagelist .success')),
+    editEventLinksTable: element(by.css('.results')),
     editEventLinks: element.all(by.css(
         '.results th > [href*="/aldryn_events/event/"]')),
 
     // adding event to the page
     advancedSettingsOption: element(by.css(
-        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
-    modalIframe: element(by.css('.cms_modal-frame iframe')),
+        '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     eventsOption: element(by.css('option[value="EventListAppHook"]')),
-    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
+    saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
     eventMetaBlock: element(by.css('.aldryn-events-meta')),
     eventsCalendarBlock: element(by.css('.aldryn-events-calendar')),
     eventLink: element(by.css('.aldryn-events-list h2 > a')),
@@ -76,26 +80,34 @@ var eventsPage = {
         credentials = credentials ||
             { username: 'admin', password: 'admin' };
 
-        eventsPage.usernameInput.clear();
+        page.usernameInput.clear();
 
         // fill in email field
-        return eventsPage.usernameInput.sendKeys(credentials.username)
-            .then(function () {
-            eventsPage.passwordInput.clear();
+        page.usernameInput.sendKeys(
+            credentials.username).then(function () {
+            page.passwordInput.clear();
 
             // fill in password field
-            return eventsPage.passwordInput.sendKeys(credentials.password);
+            return page.passwordInput.sendKeys(
+                credentials.password);
         }).then(function () {
-            eventsPage.loginButton.click();
+            return page.loginButton.click();
+        }).then(function () {
+            // this is required for django1.6, because it doesn't redirect
+            // correctly from admin
+            browser.get(page.site);
 
             // wait for user menu to appear
-            cmsProtractorHelper.waitFor(eventsPage.userMenus.first());
+            browser.wait(browser.isElementPresent(
+                page.userMenus.first()),
+                page.mainElementsWaitTime);
 
             // validate user menu
-            expect(eventsPage.userMenus.first().isDisplayed()).toBeTruthy();
+            expect(page.userMenus.first().isDisplayed())
+                .toBeTruthy();
         });
     }
 
 };
 
-module.exports = eventsPage;
+module.exports = page;

--- a/aldryn_events/tests/frontend/integration/specs/spec.events.crud.js
+++ b/aldryn_events/tests/frontend/integration/specs/spec.events.crud.js
@@ -24,13 +24,9 @@ describe('Aldryn Events tests: ', function () {
             if (present === true) {
                 // go to the main page
                 browser.get(eventsPage.site + '?edit');
-            } else {
-                // click edit mode link
-                eventsPage.editModeLink.click();
+                browser.sleep(1000);
+                cmsProtractorHelper.waitForDisplayed(eventsPage.usernameInput);
             }
-
-            // wait for username input to appear
-            cmsProtractorHelper.waitFor(eventsPage.usernameInput);
 
             // login to the site
             eventsPage.cmsLogin();
@@ -38,6 +34,17 @@ describe('Aldryn Events tests: ', function () {
     });
 
     it('creates a new test page', function () {
+        // close the wizard if necessary
+        eventsPage.modalCloseButton.isDisplayed().then(function (displayed) {
+            if (displayed) {
+                eventsPage.modalCloseButton.click();
+            }
+        });
+
+        cmsProtractorHelper.waitForDisplayed(eventsPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+
         // click the example.com link in the top menu
         return eventsPage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear
@@ -50,7 +57,7 @@ describe('Aldryn Events tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(
-                By.css('.cms_sideframe-frame iframe')));
+                By.css('.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(eventsPage.pagesLink);
 
@@ -108,13 +115,18 @@ describe('Aldryn Events tests: ', function () {
 
                 // switch to sidebar menu iframe
                 return browser.switchTo().frame(browser.findElement(By.css(
-                    '.cms_sideframe-frame iframe')));
+                    '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
-            cmsProtractorHelper.waitFor(eventsPage.breadcrumbsLinks.first());
+            browser.sleep(1000);
 
-            // click the Home link in breadcrumbs
-            eventsPage.breadcrumbsLinks.first().click();
+            eventsPage.breadcrumbs.isPresent().then(function (present) {
+                if (present) {
+                    // click the Home link in breadcrumbs
+                    cmsProtractorHelper.waitFor(eventsPage.breadcrumbsLinks.first());
+                    eventsPage.breadcrumbsLinks.first().click();
+                }
+            });
 
             cmsProtractorHelper.waitFor(eventsPage.eventsConfigsLink);
 
@@ -131,7 +143,7 @@ describe('Aldryn Events tests: ', function () {
 
                 cmsProtractorHelper.waitFor(eventsPage.namespaceInput);
 
-                return eventsPage.namespaceInput.sendKeys('aldryn_events')
+                return eventsPage.namespaceInput.sendKeys('custom_aldryn_events')
                     .then(function () {
                     return eventsPage.applicationTitleInput.sendKeys('Test application');
                 }).then(function () {
@@ -204,7 +216,7 @@ describe('Aldryn Events tests: ', function () {
 
                     // switch to modal iframe
                     browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_modal-frame iframe')));
+                        '.cms-modal-frame iframe')));
 
                     cmsProtractorHelper.selectOption(eventsPage.applicationSelect,
                         'Events', eventsPage.eventsOption);
@@ -228,6 +240,16 @@ describe('Aldryn Events tests: ', function () {
                     expect(eventsPage.eventsCalendarBlock.isDisplayed())
                         .toBeTruthy();
 
+                    // wait till animation of sideframe opening finishes
+                    browser.sleep(300);
+
+                    // close sideframe (it covers the link)
+                    cmsProtractorHelper.waitFor(eventsPage.sideFrameClose);
+                    eventsPage.sideFrameClose.click();
+
+                    // wait till animation finishes
+                    browser.sleep(300);
+
                     // click the link to go to the event page
                     return eventsPage.eventLink.click();
                 }).then(function () {
@@ -248,18 +270,33 @@ describe('Aldryn Events tests: ', function () {
     });
 
     it('deletes event', function () {
-        // wait for modal iframe to appear
-        cmsProtractorHelper.waitFor(eventsPage.sideMenuIframe);
+        // have to wait till animation finished
+        browser.sleep(300);
+        // click the example.com link in the top menu
+        eventsPage.userMenus.first().click().then(function () {
+            // wait for top menu dropdown options to appear
+            cmsProtractorHelper.waitForDisplayed(eventsPage.userMenuDropdown);
+
+            return eventsPage.administrationOptions.first().click();
+        }).then(function () {
+            // wait for modal iframe to appear
+            cmsProtractorHelper.waitFor(eventsPage.sideMenuIframe);
+        });
 
         // switch to sidebar menu iframe
         browser.switchTo()
-            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+            .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
-        // wait for edit event link to appear
-        cmsProtractorHelper.waitFor(eventsPage.editEventLinks.first());
-
-        // validate edit event links texts to find proper event for deletion
-        return eventsPage.editEventLinks.first().getText().then(function (text) {
+        // browser.pause();
+        cmsProtractorHelper.waitFor(eventsPage.editEventLink);
+        browser.sleep(100);
+        eventsPage.editEventLink.click().then(function () {
+            // wait for edit event link to appear
+            return cmsProtractorHelper.waitFor(eventsPage.editEventLinksTable);
+        }).then(function () {
+            // validate edit event links texts to delete proper event
+            return eventsPage.editEventLinks.first().getText();
+        }).then(function (text) {
             if (text === eventName) {
                 return eventsPage.editEventLinks.first().click();
             } else {

--- a/aldryn_events/tests/frontend/protractor.conf.js
+++ b/aldryn_events/tests/frontend/protractor.conf.js
@@ -15,8 +15,7 @@ var browsers = baseConf.sauceLabsBrowsers;
 var config = {
     // Capabilities to be passed to the webdriver instance.
     capabilities: {
-        'browserName': 'phantomjs',
-        'phantomjs.binary.path': require('phantomjs').path
+        'browserName': 'chrome'
     },
 
     onPrepare: function () {
@@ -31,7 +30,8 @@ var config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 3000000
+        defaultTimeoutInterval: 3000000,
+        realtimeFailure: true
     }
 
 };

--- a/test_settings.py
+++ b/test_settings.py
@@ -2,6 +2,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from distutils.version import LooseVersion
+from cms import __version__ as cms_string_version
+
+cms_version = LooseVersion(cms_string_version)
+
 
 def noop_gettext(s):
     return s
@@ -103,6 +108,8 @@ HELPER_SETTINGS = {
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
+        # NOTE: This will actually be removed below in CMS<3.2 installs.
+        'cms.middleware.utils.ApphookReloadMiddleware',
         'cms.middleware.language.LanguageCookieMiddleware',
         'cms.middleware.user.CurrentUserMiddleware',
         'cms.middleware.page.CurrentPageMiddleware',
@@ -118,6 +125,15 @@ try:
     HELPER_SETTINGS['INSTALLED_APPS'].append('django_tablib')
 except ImportError:
     pass
+
+
+# If using CMS 3.2+, use the CMS middleware for ApphookReloading, otherwise,
+# use aldryn_apphook_reload's.
+if cms_version < LooseVersion('3.2.0'):
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].remove(
+        'cms.middleware.utils.ApphookReloadMiddleware')
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].insert(
+        0, 'aldryn_apphook_reload.middleware.ApphookReloadMiddleware')
 
 
 def run():

--- a/test_settings.py
+++ b/test_settings.py
@@ -29,6 +29,7 @@ HELPER_SETTINGS = {
         'sortedm2m',
         'standard_form',
     ],
+    'CMS_PERMISSION': True,
     'LANGUAGES': (
         ('en', 'English'),
         ('de', 'German'),

--- a/test_settings.py
+++ b/test_settings.py
@@ -100,7 +100,6 @@ HELPER_SETTINGS = {
         }
     },
     'MIDDLEWARE_CLASSES': [
-        'aldryn_apphook_reload.middleware.ApphookReloadMiddleware',
         'django.middleware.http.ConditionalGetMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/test_settings.py
+++ b/test_settings.py
@@ -100,6 +100,8 @@ HELPER_SETTINGS = {
         }
     },
     'MIDDLEWARE_CLASSES': [
+        # NOTE: This will actually be removed below in CMS<3.2 installs.
+        'cms.middleware.utils.ApphookReloadMiddleware',
         'django.middleware.http.ConditionalGetMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -107,8 +109,6 @@ HELPER_SETTINGS = {
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
-        # NOTE: This will actually be removed below in CMS<3.2 installs.
-        'cms.middleware.utils.ApphookReloadMiddleware',
         'cms.middleware.language.LanguageCookieMiddleware',
         'cms.middleware.user.CurrentUserMiddleware',
         'cms.middleware.page.CurrentPageMiddleware',


### PR DESCRIPTION
- changes tests so they work with 3.2
    - sideframe is now covering most of the view so it has to be opened/closed
    - admin behaviour changed slightly
    - selectors changed
    - added additional safety waits
- change the default local runner from phantomjs to chrome because literally nothing works in phantom (and http://www.protractortest.org/#/browser-support)
- add CMS_PERMISSION setting, because apparently there is a bug in the 3.2 that hides the Pages menu item if it's not set
- add correct apphook reload to test server configuration