### PR TITLE
don't add django_tablib to INSTALLED_APPS

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -9,7 +9,6 @@
         "aldryn_translation_tools",
         "appconf",
         "bootstrap3",
-        "django_tablib",
         "djangocms_text_ckeditor",
         "easy_thumbnails",
         "extended_choices",

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -11,4 +11,18 @@ class Form(forms.BaseForm):
             style = style.strip()
             choices.append((style, style))
         settings['ALDRYN_EVENTS_PLUGIN_STYLES'] = choices
+        try:
+            # If django_tablib is available, use it.
+            # This logic is here, because the official version of
+            # django-tablib currently does not support Django 1.9.
+            # So we can't install it by default from setup.py.
+            # On aldryn the aldryn-django Addon will install the appropriate
+            # patched version of django-tablib, so it should be available.
+            # Once django-tablib works with all required Django versions again
+            # this logic can be removed and django-tablib can be added to
+            # setup.py again.
+            import django_tablib
+            settings['INSTALLED_APPS'].append('django_tablib')
+        except ImportError:
+            pass
         return settings


### PR DESCRIPTION
django-tablib is currently not installed required in setup.py, because 
it does not work with Django 1.9.

Only if it is actually installed, add it to INSTALLED_APPS.

Note: Importing stuff in Form.to_settings() only works in BaseProject
v3 based Projects.