### PR TITLE
install django-tablib by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,28 +34,6 @@ Requirements
 * Django 1.6 - 1.9
 
 
-Optional requirements
-=====================
-
-* django-tablib
-
-Package should be installed manually. Also take in account ``django-tablib``
-limitations which are listed below.
-
-Python 2.6
-----------
-
-If you are planning to use ``aldryn-events`` with ``Python 2.6``
-be aware that event registrations export functions will not work because
-``django-tablib`` package has ``Python 2.6``/``Django 1.6+`` compatibility issues.
-
-Django 1.8
-----------
-
-Unfortunately ``django-tablib`` does not supports ``Django 1.8`` which means
-that event registrations export functions will not work.
-
-
 .. |PyPI Version| image:: http://img.shields.io/pypi/v/aldryn-events.svg
    :target: https://pypi.python.org/pypi/aldryn-events
 .. |Build Status| image:: http://img.shields.io/travis/aldryn/aldryn-events/master.svg

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -11,18 +11,5 @@ class Form(forms.BaseForm):
             style = style.strip()
             choices.append((style, style))
         settings['ALDRYN_EVENTS_PLUGIN_STYLES'] = choices
-        try:
-            # If django_tablib is available, use it.
-            # This logic is here, because the official version of
-            # django-tablib currently does not support Django 1.9.
-            # So we can't install it by default from setup.py.
-            # On aldryn the aldryn-django Addon will install the appropriate
-            # patched version of django-tablib, so it should be available.
-            # Once django-tablib works with all required Django versions again
-            # this logic can be removed and django-tablib can be added to
-            # setup.py again.
-            import django_tablib
-            settings['INSTALLED_APPS'].append('django_tablib')
-        except ImportError:
-            pass
+        settings['INSTALLED_APPS'].append('django_tablib')
         return settings

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ REQUIREMENTS = [
     'django-parler>=1.6.1',
     'django-sortedm2m',
     'django-standard-form>=1.1.1',
+    'django-tablib',
     'djangocms-text-ckeditor',
     'python-dateutil',
 ]


### PR DESCRIPTION
django-tablib now has a release on pypi that also works in Django 1.8
and 1.9, so we can make it a real dependency and set it up by default.