### PR TITLE
Fixed migration 0007

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.1.5 (unreleased)
+------------------
+
+* Fix migrations for blank projects
+
+
 1.1.4 (2016-07-07)
 ------------------
 

--- a/aldryn_events/migrations/0007_set_default_namespaces.py
+++ b/aldryn_events/migrations/0007_set_default_namespaces.py
@@ -32,18 +32,11 @@ def create_default_namespaces(apps, schema_editor):
         if not model.objects.exists():
             # If there are no object yet, of this type, do nothing.
             continue
-        try:
-            # to avoid the following error:
-            #   django.db.utils.InternalError: current transaction is aborted,
-            #   commands ignored until end of transaction block
-            # we need to cleanup or avoid that by making them atomic.
-            with transaction.atomic():
-                model_objects = list(model.objects.filter(
-                    app_config__isnull=True))
-        except (ProgrammingError, OperationalError):
-            # If the above didn't work, do NOT attempt to access django.apps
-            # directly as this will cause issues in future releases. Just pass.
-            pass
+
+        with transaction.atomic():
+            model_objects = list(model.objects.filter(
+                app_config__isnull=True))
+
         for entry in model_objects:
             entry.app_config = app_config
             entry.save()

--- a/aldryn_events/migrations/0007_set_default_namespaces.py
+++ b/aldryn_events/migrations/0007_set_default_namespaces.py
@@ -29,7 +29,7 @@ def create_default_namespaces(apps, schema_editor):
         # migrate this - we would get an exception because apps.get_model
         # contains cms models at point of dependency migration
         # so if that is the case - import real model.
-        if not model.objects.exists():
+        if not model.objects.filter(app_config__isnull=True).exists():
             # If there are no object yet, of this type, do nothing.
             continue
 


### PR DESCRIPTION
Migration 0007 contained logic that, in some conditions, will break if any future commit adds a field to the Event model or any of the plugins.

This PR attempts to fix that migration so that it may run in all of these cases.