### PR TITLE
Change tox `cms35` variable to point to latest version of django cms 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps=
     cms34: django-cms>=3.4,<3.5
     cms34: djangocms-text-ckeditor>=3.0,<3.1
 
-    cms35: https://github.com/divio/django-cms/archive/develop.zip
+    cms35: django-cms>=3.5,<3.6
     cms35: djangocms-text-ckeditor>=3.0
 
     doctest: -rtest_requirements/docs_test.txt


### PR DESCRIPTION
Before this change, `cms35` variable was pointing to develop branch of django cms.